### PR TITLE
Pet id should default to 0 for JPA

### DIFF
--- a/AdoptionSpringBootJPA/src/main/java/adoption/domain/Pet.java
+++ b/AdoptionSpringBootJPA/src/main/java/adoption/domain/Pet.java
@@ -33,7 +33,7 @@ public class Pet {
     }
 
     public Pet(PetType type, String name, String breed){
-        this(1,type,name,breed);
+        this(0,type,name,breed);
     }
 
     public int getPetId() {
@@ -41,9 +41,9 @@ public class Pet {
     }
 
     public void setPetId(int petId) {
-        if (petId == 0){
-            throw new IllegalArgumentException("Invalid Argument: Pet ID can't be zero or null.");
-        }
+//        if (petId == 0){
+//            throw new IllegalArgumentException("Invalid Argument: Pet ID can't be zero or null.");
+//        }
         this.petId = petId;
     }
 

--- a/AdoptionSpringBootJPA/src/main/resources/application-postgres.properties
+++ b/AdoptionSpringBootJPA/src/main/resources/application-postgres.properties
@@ -3,7 +3,7 @@
 spring.datasource.url=jdbc:postgresql://localhost:5433/adoptapp
 spring.datasource.username=larku
 spring.datasource.password=${DB_PASSWORD}
-#spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 #Tell Spring not to create the database
 #Choice are 'never', 'embedded' and 'always'
@@ -13,10 +13,10 @@ spring.sql.init.mode=never
 #If we still want to have both Hibernate automatic schema
 #generation in conjugation with script-based schema creation and data population
 #This will ensure, that after Hibernate schema creation is performed
-# hen additionally schema.sql is read for any additional schema changes
+#Then additionally schema.sql is read for any additional schema changes
 #and data.sql is executed to populate the database.
 #spring.jpa.defer-datasource-initialization=true
-spring.jpa.defer-datasource-initialization=false
+#spring.jpa.defer-datasource-initialization=false
 
 #spring.sql.init.schema-locations = classpath:/sql/postgres/1-adoptapp-postgres_schema.sql
 #spring.sql.init.data-locations = classpath:/sql/postgres/2-adoptapp-postgres_data.sql

--- a/AdoptionSpringBootJPA/src/test/java/adoption/dao/repository/AdopterRepoTest.java
+++ b/AdoptionSpringBootJPA/src/test/java/adoption/dao/repository/AdopterRepoTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -41,7 +42,7 @@ public class AdopterRepoTest {
     @Test
     public void testInsertAdopterWithPet(){
         Pet pet = new Pet(Pet.PetType.TURTLE, "Frankie", "Red-Eared Slider");
-//        petRepo.save(pet);
+//        pet = petRepo.save(pet);
 
 //        Optional<Pet> opt = petRepo.findById(5);
 //        if (opt.isPresent()){


### PR DESCRIPTION
Hi, that was tricky to find, but eventually was an easy fix.

You have your Pet id default to 1.  Hibernate looks at that 
id when it is trying to persist the the Adopter, and assumes
that that is an already existing Pet.  Hence the message about 
a "detached" Entity.  "Detached" in JPA terms means this is in object
that already exists in the database but is not attached to a Persistence 
context yet.

The fix is to default your Pet id to 0.  This may require some changes to
your tests.  I did have to turn off the validation you had in Pet::setId

Let me know if this does/does not make sense. 